### PR TITLE
Synchronize SDK

### DIFF
--- a/com.obsproject.Studio.Plugin.DistroAV.json
+++ b/com.obsproject.Studio.Plugin.DistroAV.json
@@ -2,7 +2,7 @@
     "app-id": "com.obsproject.Studio.Plugin.DistroAV",
     "runtime": "com.obsproject.Studio",
     "runtime-version": "stable",
-    "sdk": "org.kde.Sdk//6.8",
+    "sdk": "org.freedesktop.Sdk//25.08",
     "build-extension": true,
     "separate-locales": false,
     "build-options": {


### PR DESCRIPTION
32.1 dropped KDE runtime.